### PR TITLE
Add option to example configuration required by ticket-monitor-queue.py

### DIFF
--- a/salesforce.conf.example
+++ b/salesforce.conf.example
@@ -20,3 +20,4 @@ favicon =
 [misc]
 shift_status_json_url =
 monitor_poll_minutes = 5
+monitor_group_name =


### PR DESCRIPTION
Add option to example configuration required by ticket-monitor-queue.py

The monitor_group_name setting was missing from the example configuration file.
This option is required by ticket-monitor-queue.py
